### PR TITLE
Add recv stream id so stream can be tracked during callbacks

### DIFF
--- a/lib/wtransport/stream.ex
+++ b/lib/wtransport/stream.ex
@@ -1,5 +1,6 @@
 defmodule Wtransport.Stream do
   defstruct [
+    :recv_stream_id,
     :stream_type,
     :connection,
     :request_tx,

--- a/native/wtransport_native/src/lib.rs
+++ b/native/wtransport_native/src/lib.rs
@@ -70,6 +70,7 @@ struct NifConnectionRequest {
 #[derive(NifStruct)]
 #[module = "Wtransport.StreamRequest"]
 struct NifStreamRequest {
+    recv_stream_id: u64,
     stream_type: Atom,
     request_tx: ResourceArc<XRequestSender>,
     write_all_tx: Option<ResourceArc<XDataSender>>,
@@ -446,11 +447,13 @@ async fn handle_stream(
             atoms::stream_request(),
             match send_stream {
                 Some(_) => NifStreamRequest {
+                    recv_stream_id: recv_stream.id().into_u64(),
                     stream_type: atoms::bi(),
                     request_tx: ResourceArc::new(XRequestSender(request_tx)),
                     write_all_tx: Some(ResourceArc::new(XDataSender(write_all_tx))),
                 },
                 None => NifStreamRequest {
+                    recv_stream_id: recv_stream.id().into_u64(),
                     stream_type: atoms::uni(),
                     request_tx: ResourceArc::new(XRequestSender(request_tx)),
                     write_all_tx: None,


### PR DESCRIPTION
Right now there doesn't seem to be a way to identify where incoming bytes came from in terms of the original stream. (You can only see the connection, and the stream struct lacks identifying information.) This adds the recv_stream id to the struct.